### PR TITLE
optional custom headers and auth object for session

### DIFF
--- a/fhir_kindling/fhir_query/query_response.py
+++ b/fhir_kindling/fhir_query/query_response.py
@@ -256,10 +256,7 @@ class QueryResponse:
                     entries.extend(added_entries)
                     # Stop resolving the pagination when the limit is reached
                     if self._limit:
-                        if len(entries) >= self._limit:
-                            next_page = False
-                        else:
-                            next_page = True
+                        next_page = len(entries) < self._limit
                     else:
                         next_page = True
 
@@ -276,6 +273,7 @@ class QueryResponse:
         link = response.get("link", None)
         # If there is a link, get the next page otherwise return the response
         if not link:
+            self.status_code = ResponseStatusCodes.OK
             return response
         else:
             entries = []


### PR DESCRIPTION
resolves #50 

optionally pass custom headers and/or auth objects

```python
auth = HTTPBasicAuth(username="test", password="test")
headers = {"X-Custom-Header": "Test", "X-Custom-Header2": "Test2"}
server = FhirServer(api_address="https://fhir.test/fhir", headers=headers, auth=auth)

```
