### PR TITLE
callbacks for paginated responses, get, get_many by reference

### DIFF
--- a/fhir_kindling/fhir_query/fhir_query.py
+++ b/fhir_kindling/fhir_query/fhir_query.py
@@ -1,7 +1,8 @@
-from typing import Union
+from typing import Union, Callable, List, Any
 from fhir.resources.resource import Resource
 from fhir.resources.bundle import Bundle
 from fhir.resources.fhirresourcemodel import FHIRResourceModel
+from fhir.resources import FHIRAbstractModel
 import fhir.resources
 import requests
 import requests.auth
@@ -18,8 +19,7 @@ class FHIRQuery:
                  query_parameters: FHIRQueryParameters = None,
                  auth: requests.auth.AuthBase = None,
                  session: requests.Session = None,
-                 output_format: str = "json",
-                 count: int = 5000):
+                 output_format: str = "json"):
 
         self.base_url = base_url
 
@@ -30,22 +30,29 @@ class FHIRQuery:
         else:
             self._setup_session()
 
-        # initialize the resource
-        if isinstance(resource, str):
-            self.resource = fhir.resources.get_fhir_model_class(resource)
-        else:
-            self.resource = resource
+        # initialize the resource and query parameters
+        if resource:
+            if isinstance(resource, str):
+                self.resource = fhir.resources.get_fhir_model_class(resource)
+            elif isinstance(resource, FHIRResourceModel) or isinstance(resource, FHIRAbstractModel):
+                self.resource = resource
+            else:
+                raise ValueError(f"resource must be a FHIRResourceModel or a string, given {type(resource)}")
+            self.resource = self.resource.construct()
+            self.query_parameters = FHIRQueryParameters(resource=self.resource.resource_type)
 
-        self.resource = self.resource.construct()
+        elif query_parameters:
+            self.query_parameters = query_parameters
+            self.resource = fhir.resources.get_fhir_model_class(query_parameters.resource)
+            self.resource = self.resource.construct()
+        else:
+            raise ValueError("Either resource or query_parameters must be set")
+
         self.output_format = output_format
         self._includes = None
         self._limit = None
-        self._count = count
-        self._query_response: Union[Bundle, str] = None
-        if query_parameters:
-            self.query_parameters = query_parameters
-        else:
-            self.query_parameters: FHIRQueryParameters = FHIRQueryParameters(resource=self.resource.resource_type)
+        self._count = None
+        self._query_response: Union[Bundle, str, None] = None
 
     def where(self,
               field: str = None,
@@ -221,22 +228,34 @@ class FHIRQuery:
 
         return self
 
-    def all(self):
+    def all(self,
+            page_callback: Union[Callable[[List[FHIRAbstractModel]], Any], Callable[[], Any], None] = None,
+            count: int = None) -> QueryResponse:
         """
         Execute the query and return all results matching the query parameters.
+
+        Args:
+            page_callback: if this argument is set the given callback function will be called for each page of results
+            count: number of results in a page, default value of 50 is used when page_callback is set but no count is
         Returns:
             QueryResponse object containing all resources matching the query, as well os optional included
             resources.
 
         """
         self._limit = None
-        return self._execute_query()
+        self._count = count
+        return self._execute_query(page_callback=page_callback, count=count)
 
-    def limit(self, n: int):
+    def limit(self,
+              n: int,
+              page_callback: Union[Callable[[List[FHIRAbstractModel]], Any], Callable[[], Any], None] = None,
+              count: int = None) -> QueryResponse:
         """
         Execute the query and return the first n results matching the query parameters.
         Args:
             n: number of resources to return
+            page_callback: if this argument is set the given callback function will be called for each page of results
+            count: number of results in a page, default value of 50 is used when page_callback is set but no count is
 
         Returns:
             QueryResponse object containing the first n resources matching the query, as well os optional included
@@ -244,9 +263,10 @@ class FHIRQuery:
 
         """
         self._limit = n
-        return self._execute_query()
+        self._count = count
+        return self._execute_query(page_callback=page_callback, count=count)
 
-    def first(self):
+    def first(self) -> QueryResponse:
         """
         Return the first resource matching the query parameters.
         Returns:
@@ -287,7 +307,9 @@ class FHIRQuery:
         self.session.auth = self.auth
         self.session.headers.update({"Content-Type": "application/fhir+json"})
 
-    def _execute_query(self):
+    def _execute_query(self,
+                       page_callback: Union[Callable[[List[FHIRAbstractModel]], Any], Callable[[], Any], None] = None,
+                       count: int = None) -> QueryResponse:
         r = self.session.get(self.query_url)
         r.raise_for_status()
         response = QueryResponse(
@@ -295,13 +317,19 @@ class FHIRQuery:
             response=r,
             query_params=self.query_parameters,
             output_format=self.output_format,
-            limit=self._limit
+            limit=self._limit,
+            count=count,
+            page_callback=page_callback,
         )
         return response
 
-    def _make_query_string(self):
-        query_string = f"{self.base_url}{self.query_parameters.to_query_string()}"
-        if self._limit:
+    def _make_query_string(self) -> str:
+        query_string = self.base_url + self.query_parameters.to_query_string()
+
+        if not self._count:
+            self._count = 5000
+
+        if self._limit and self._limit < self._count:
             query_string += f"&_count={self._limit}"
         else:
             query_string += f"&_count={self._count}"

--- a/tests/test_fhir_query.py
+++ b/tests/test_fhir_query.py
@@ -1372,6 +1372,7 @@ def test_query_json(server):
     includes = result.included_resources
     assert not includes
 
+
 def test_query_first(server):
     query = server.query("Patient")
     result = query.first()
@@ -1385,6 +1386,24 @@ def test_query_limit(server):
     query._count = 30
     result = query.limit(100)
     assert len(result.resources) == 100
+
+
+def test_query_with_callback(server):
+    def callback1(resources):
+        print(len(resources))
+
+    server.query("Patient").all(page_callback=callback1, count=50)
+
+    def callback2():
+        print("callback2")
+
+    server.query("Patient").all(page_callback=callback2, count=200)
+
+    with pytest.raises(ValueError):
+        def callback3(a, b):
+            print("callback3")
+
+        server.query("Patient").all(page_callback=callback3, count=200)
 
 
 def test_query_response_resources(server):

--- a/tests/test_fhir_server.py
+++ b/tests/test_fhir_server.py
@@ -11,6 +11,8 @@ from fhir.resources.organization import Organization
 from fhir.resources.address import Address
 from fhir.resources.bundle import Bundle, BundleEntry, BundleEntryRequest
 from fhir.resources.patient import Patient
+
+from fhir_kindling.fhir_query import FHIRQueryParameters
 from fhir_kindling.generators import PatientGenerator
 
 
@@ -309,7 +311,7 @@ def test_server_add_all(fhir_server: FhirServer):
 
 
 def test_query_all(fhir_server: FhirServer):
-    response = fhir_server.query(Patient, output_format="dict").all()
+    response = fhir_server.query(Patient.construct(), output_format="dict").all()
     print(response)
     assert response.response
 
@@ -326,7 +328,7 @@ def test_query_with_string_resource(fhir_server: FhirServer):
 
 
 def test_query_with_limit(fhir_server: FhirServer):
-    response = fhir_server.query(Patient, output_format="dict").limit(2)
+    response = fhir_server.query(Patient.construct(), output_format="dict").limit(2)
 
     assert response.response["entry"]
 
@@ -429,6 +431,36 @@ def test_custom_auth():
 
     with pytest.raises(ValueError):
         server = FhirServer(api_address="https://fhir.test/fhir", auth=auth, client_id="test")
+
+
+def test_query_with_params(fhir_server: FhirServer):
+    params = FHIRQueryParameters(
+        resource="Condition"
+    )
+    query = fhir_server.query(query_parameters=params)
+    response = query.all()
+
+    assert response.resources
+
+
+def test_fhir_server_get(fhir_server: FhirServer):
+    patient = fhir_server.query("Patient").first().resources[0]
+
+    patient_by_reference = fhir_server.get(patient.relative_path())
+
+    assert patient_by_reference.id == patient.id
+
+
+def test_fhir_server_get_many(fhir_server: FhirServer):
+    patients = fhir_server.query("Patient").limit(10).resources
+
+    references = [p.relative_path() for p in patients]
+    patients_by_reference = fhir_server.get_many(references)
+
+    assert len(patients_by_reference) == len(patients)
+
+    for p, p2 in zip(patients, patients_by_reference):
+        assert p.id == p2.id
 
 
 def test_server_repr_str(fhir_server: FhirServer):


### PR DESCRIPTION
Callbacks supporting a single optional argument which will contain the list of resources received from the paginated response
```python
query.all(page_callback=lamda x: print(len(x)), count=50)
```
Get single or many resources by reference

```python
patient_1 = server.get("Patient/1")

patients = server.get_many(["Patient/1", "Patient/2"])

```