### PR TITLE
Fixed a python warning

### DIFF
--- a/fhir_kindling/serde/flatten.py
+++ b/fhir_kindling/serde/flatten.py
@@ -1,5 +1,5 @@
 from typing import Union, List
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 import pandas as pd
 from fhir.resources import FHIRAbstractModel


### PR DESCRIPTION
Without this I would have this warning:

```
local.virtualenv/lib/python3.9/site-packages/fhir_kindling/serde/flatten.py:2
  /mnt/ssd/dev/yaal/lum1/local.virtualenv/lib/python3.9/site-packages/fhir_kindling/serde/flatten.py:2: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import MutableMapping

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```